### PR TITLE
mysql-connector-cpp: fix install locations

### DIFF
--- a/mysql-connector-cpp.yaml
+++ b/mysql-connector-cpp.yaml
@@ -37,7 +37,8 @@ pipeline:
         -DWITH_LZ4=system \
         -DWITH_SSL=system \
         -DWITH_ZLIB=system \
-        -DWITH_ZSTD=system
+        -DWITH_ZSTD=system \
+        -DCMAKE_INSTALL_DOCDIR=share/doc/${{package.name}}
 
   - uses: cmake/build
 
@@ -54,16 +55,14 @@ subpackages:
   - name: ${{package.name}}-dev
     pipeline:
       - uses: split/dev
+      - runs: |
+          mv ${{targets.destdir}}/usr/share ${{targets.contextdir}}/usr
+          mkdir -p ${{targets.contextdir}}/usr/lib/cmake/mysql-concpp
+          mv ${{targets.destdir}}/usr/*.cmake ${{targets.contextdir}}/usr/lib/cmake/mysql-concpp/
     dependencies:
       replaces:
         - ${{package.name}}
     description: ${{package.name}} dev
-
-  - name: ${{package.name}}-doc
-    pipeline:
-      - uses: split/manpages
-      - uses: split/infodir
-    description: ${{package.name}} manpages
 
 update:
   enabled: true


### PR DESCRIPTION
Note that currently doc package is empty

```
$ tar tf mysql-connector-cpp-doc-9.0.0-r0.apk 2>/dev/null
.SIGN.RSA.local-melange.rsa.pub
.PKGINFO
var
var/lib
var/lib/db
var/lib/db/sbom
var/lib/db/sbom/mysql-connector-cpp-doc-9.0.0-r0.spdx.json
```

and dev package has:

```
$ tar tf mysql-connector-cpp-9.0.0-r0.apk 2>/dev/null
.SIGN.RSA.local-melange.rsa.pub
.PKGINFO
usr
usr/INFO_BIN
usr/INFO_SRC
usr/lib
usr/lib/libmysqlcppconnx.so.2
usr/lib/libmysqlcppconnx.so.2.9.0.0
usr/mysql-concpp-config-version.cmake
usr/mysql-concpp-config.cmake
var
var/lib
var/lib/db
var/lib/db/sbom
var/lib/db/sbom/mysql-connector-cpp-9.0.0-r0.spdx.json
```

The INFO files should be usr/share/doc/... and the cmake files should be in usr/lib/cmake/mysql-concpp/...

Upsteam cmake doesn't do location detection, so help by passing in correct locations for the package split to work.

with these fixes the -dev package now has

```
usr/lib
usr/lib/cmake
usr/lib/cmake/mysql-concpp
usr/lib/cmake/mysql-concpp/mysql-concpp-config-version.cmake
usr/lib/cmake/mysql-concpp/mysql-concpp-config.cmake
usr/lib/libmysqlcppconnx.so
usr/share
usr/share/doc
usr/share/doc/mysql-connector-cpp
usr/share/doc/mysql-connector-cpp/INFO_BIN
usr/share/doc/mysql-connector-cpp/INFO_SRC
```

Like a good project that uses CMake correctly.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
